### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -11,10 +11,10 @@ function logDebug(message: string, debug?: boolean) {
     if (debug) {
         // Sanitize the message to remove sensitive information
         const sanitizedMessage = sanitizeSensitiveData(message);
-        if (!sanitizedMessage.includes("password") && !sanitizedMessage.includes("username") && !sanitizedMessage.includes("apn")) {
-            console.log(`[DEBUG] ${sanitizedMessage}`);
-        } else {
+        if (sanitizedMessage.includes("****")) {
             console.log(`[DEBUG] Sensitive information omitted`);
+        } else {
+            console.log(`[DEBUG] ${sanitizedMessage}`);
         }
     }
 }
@@ -30,7 +30,11 @@ function sanitizeSensitiveData(message: string): string {
         .replace(/--username=\S+/g, '--username=****')
         .replace(/--apn=\S+/g, '--apn=****')
         .replace(/--auth-type=\S+/g, '--auth-type=****')
-        .replace(/--ip-family=\S+/g, '--ip-family=****');
+        .replace(/--ip-family=\S+/g, '--ip-family=****')
+        .replace(/--device=\S+/g, '--device=****')
+        .replace(/--set-client-id \S+/g, '--set-client-id ****')
+        .replace(/--get-client-id \S+/g, '--get-client-id ****')
+        .replace(/--sync/g, '--sync ****');
 }
 
 /**

--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -9,7 +9,9 @@ import { SSHOptions } from "../types";
  */
 function logDebug(message: string, debug?: boolean) {
     if (debug) {
-        console.log(`[DEBUG] ${message}`);
+        // Sanitize the message to remove sensitive information
+        const sanitizedMessage = message.replace(/--password=\S+/g, '--password=****');
+        console.log(`[DEBUG] ${sanitizedMessage}`);
     }
 }
 

--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -11,7 +11,11 @@ function logDebug(message: string, debug?: boolean) {
     if (debug) {
         // Sanitize the message to remove sensitive information
         const sanitizedMessage = sanitizeSensitiveData(message);
-        console.log(`[DEBUG] ${sanitizedMessage}`);
+        if (!sanitizedMessage.includes("password") && !sanitizedMessage.includes("username") && !sanitizedMessage.includes("apn")) {
+            console.log(`[DEBUG] ${sanitizedMessage}`);
+        } else {
+            console.log(`[DEBUG] Sensitive information omitted`);
+        }
     }
 }
 
@@ -24,7 +28,9 @@ function sanitizeSensitiveData(message: string): string {
     return message
         .replace(/--password=\S+/g, '--password=****')
         .replace(/--username=\S+/g, '--username=****')
-        .replace(/--apn=\S+/g, '--apn=****');
+        .replace(/--apn=\S+/g, '--apn=****')
+        .replace(/--auth-type=\S+/g, '--auth-type=****')
+        .replace(/--ip-family=\S+/g, '--ip-family=****');
 }
 
 /**

--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -10,9 +10,21 @@ import { SSHOptions } from "../types";
 function logDebug(message: string, debug?: boolean) {
     if (debug) {
         // Sanitize the message to remove sensitive information
-        const sanitizedMessage = message.replace(/--password=\S+/g, '--password=****');
+        const sanitizedMessage = sanitizeSensitiveData(message);
         console.log(`[DEBUG] ${sanitizedMessage}`);
     }
+}
+
+/**
+ * Sanitizes a message to remove sensitive information such as passwords, usernames, and other credentials.
+ * @param {string} message - The message to sanitize.
+ * @returns {string} The sanitized message.
+ */
+function sanitizeSensitiveData(message: string): string {
+    return message
+        .replace(/--password=\S+/g, '--password=****')
+        .replace(/--username=\S+/g, '--username=****')
+        .replace(/--apn=\S+/g, '--apn=****');
 }
 
 /**


### PR DESCRIPTION
Fixes [https://github.com/Benjamin-Stefan/uqmi-client/security/code-scanning/1](https://github.com/Benjamin-Stefan/uqmi-client/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged. This can be achieved by sanitizing the messages before logging them. Specifically, we should avoid including the `password` field in any debug messages.

1. Modify the `logDebug` function to sanitize the message before logging it.
2. Ensure that any sensitive information is either removed or masked in the debug messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
